### PR TITLE
Check if current directory looks like a Jekyll site before running

### DIFF
--- a/bin/joke
+++ b/bin/joke
@@ -2,5 +2,19 @@
 
 require 'joke'
 
+jekyll_artifacts = %w[ _config.yml _drafts _includes _layouts _posts ]
+looks_like_jekyll = false
+jekyll_artifacts.each do |artifact|
+  looks_like_jekyll = File.exists?(artifact) unless looks_like_jekyll
+end
+unless looks_like_jekyll
+  print "This doesn’t look like a Jekyll site. Are you sure you want to run joke? [y/N]: "
+  answer = gets
+  unless answer.downcase.chomp == "y"
+    puts "No worries. Later!"
+    exit
+  end
+end
+
 puts "Firing up the Joke server…"
 Joke::App.run!

--- a/bin/joke
+++ b/bin/joke
@@ -3,17 +3,9 @@
 require 'joke'
 
 jekyll_artifacts = %w[ _config.yml _drafts _includes _layouts _posts ]
-looks_like_jekyll = false
-jekyll_artifacts.each do |artifact|
-  looks_like_jekyll = File.exists?(artifact) unless looks_like_jekyll
-end
-unless looks_like_jekyll
+unless jekyll_artifacts.any? { |artifact| File.exists?(artifact) }
   print "This doesn’t look like a Jekyll site. Are you sure you want to run joke? [y/N]: "
-  answer = gets
-  unless answer.downcase.chomp == "y"
-    puts "No worries. Later!"
-    exit
-  end
+  abort "No worries. Later!" unless gets.downcase.chomp == "y"
 end
 
 puts "Firing up the Joke server…"


### PR DESCRIPTION
This PR adds in a check to help prevent running `joke` in directories that aren’t jekyll sites (and thus littering folders with generated `_site` directories).

```
$ joke
This doesn’t look like a Jekyll site. Are you sure you want to run joke? [y/N]:
```

If merged, this should close #2 

/cc @parkr
